### PR TITLE
Add documentation for basic usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ For libraries which export their full exposed API, this works well, but some pac
 
 If your project references classes which are built into the language (e.g. `HTMLElement`), this package _will_ result in those types being documented to. If you want to prevent this, set TypeDoc's `excludeExternals` option to `true`. The default pattern for determining if a symbol is external will exclude everything within `node_modules`.
 
+### Usage
+  `npm install typedoc-plugin-missing-exports`
+
+  Typedoc will automatically use this plugin when present.
+
 ### Options
 
 -   `internalNamespace` - Define the name of the namespace that internal symbols which are not exported should be placed into.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If your project references classes which are built into the language (e.g. `HTML
 ### Usage
   `npm install typedoc-plugin-missing-exports`
 
-  Typedoc will automatically use this plugin when present.
+  TypeDoc will automatically use this plugin when present.
 
 ### Options
 


### PR DESCRIPTION
It was my first day using TypeDoc and this was the first plugin I ever tried to use.

 I didn't know that Typedoc would automatically make use of this plugin so I was kinda confused as to what to do.

This commit updates the documentation to explain how to use this package for a new user like me.

