### PR TITLE
Update typedoc version and peer dependency range

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"@types/node": "18",
 		"dprint": "^0.49.0",
 		"outdent": "^0.8.0",
-		"typedoc": "^0.28.1",
+		"typedoc": "^0.28.7",
 		"typescript": "^5.8.2",
 		"vitest": "^3.0.8"
 	},
@@ -25,7 +25,7 @@
 		"typedoc-plugin"
 	],
 	"peerDependencies": {
-		"typedoc": "^0.28.1"
+		"typedoc": ">=0.28.1 <0.29.0"
 	},
 	"scripts": {
 		"test": "vitest run test/packages.test.ts",


### PR DESCRIPTION
Bumped typedoc to ^0.28.7 in devDependencies and set peerDependencies range to >=0.28.1 <0.29.0 for improved compatibility.