### PR TITLE
Add option to also consider `{@link …}` references

### DIFF
--- a/test/packages.test.ts
+++ b/test/packages.test.ts
@@ -211,6 +211,36 @@ test("Issue #22", () => {
 	expect(toStringHierarchy(project)).toBe(hierarchy);
 });
 
+// https://github.com/Gerrit0/typedoc-plugin-missing-exports/issues/33
+test("Issue #33", () => {
+	{
+		const project = convert("gh33/index.ts");
+
+		const hierarchy = outdent`
+			Variable myGreatSymbol
+		`;
+
+		expect(toStringHierarchy(project)).toBe(hierarchy);
+	}
+	app.options.setValue("includeDocCommentReferences", true);
+	{
+		const project = convert("gh33/index.ts");
+
+		// NOTE: `ShamefullyHidden` is deliberately not included, as this plugin does not (automatically) add exports to parents of referenced symbols.
+		const hierarchy = outdent`
+			Module <internal>
+				Class GreatnessFactoryFactoryBuilderAdapterSingleton
+				Type Alias SecretType
+				Type Alias SecretType2
+				Variable myBasicSymbol
+				Function greatnessFactory
+			Variable myGreatSymbol
+		`;
+
+		expect(toStringHierarchy(project)).toBe(hierarchy);
+	}
+});
+
 test("Custom module name", () => {
 	app.options.setValue("internalModule", "internals");
 	const project = convert("single-missing-export/index.ts");

--- a/test/packages/gh33/index.ts
+++ b/test/packages/gh33/index.ts
@@ -1,0 +1,56 @@
+/**
+ * This module has a few unexported symbols which are only referenced via a {\@link} tag.
+ *
+ * It serves as a test for the the following issue: https://github.com/Gerrit0/typedoc-plugin-missing-exports/issues/33.
+ *
+ * @module
+ */
+
+/**
+ * Does what it says on the tin!
+ *
+ * For those who prefer a more Java-like approach,
+ * please see {@link GreatnessFactoryFactoryBuilderAdapterSingleton.get | get}
+ * and {@link GreatnessFactoryFactoryBuilderAdapterSingleton.build | build}
+ * on {@link GreatnessFactoryFactoryBuilderAdapterSingleton}.
+ */
+function greatnessFactory(num: SecretType) {
+	return `${num}× as great!`;
+}
+
+// used to test that combining the usual reference discovery with link discovery works.
+/** Despite JavaScript's idiosyncrasies, not the same as {@link SecretType2}! */
+type SecretType =
+	| number
+	| (void & { _: "something interesting for typedoc to document this type" });
+type SecretType2 = string;
+
+class GreatnessFactoryFactoryBuilderAdapterSingleton {
+	static get = () => {
+		// TBD. :)
+	};
+
+	build() {
+		// TBD. :)
+	}
+}
+
+/**
+ * Even better than {@link myBasicSymbol}!
+ *
+ * @see {@link greatnessFactory} — the source of all this greatness.
+ *
+ * @privateRemarks This is as great as we can let the users have—keep {@link mySecretSymbol} well hidden!
+ */
+export const myGreatSymbol = greatnessFactory(1);
+
+/** Just your regular kind of stuff. Better be glad it's not {@link ShamefullyHidden.myWorstSymbol}! */
+const myBasicSymbol = greatnessFactory(-1);
+
+/** Only for internal use! It's too powerful for the general public! */
+const mySecretSymbol = greatnessFactory(2);
+
+namespace ShamefullyHidden {
+	// must be exported, as only links resolvable by TS (i.e. what `useTsLinkResolution` does) are supported for now.
+	export const myWorstSymbol = greatnessFactory(-2);
+}


### PR DESCRIPTION
After a surprising amount of work, I'm back. :slightly_smiling_face: 

This PR adds an option to consider the `@link` family of JSDoc tags (`@link`, `@linkcode`, `@linkplain`) references to export as well. This PR only considers references that can be resolved via TypeScript (i.e. those resolved using `useTsLinkResolution`) as that is all I need. Resolving _declaration references_ should be possible too, but would likely be considerably more work.

This turned out to be quite a bit more difficult than I expected, as, unlike the other references that this plugin considers, the linked items do not get reflections created by TypeDoc. Furthermore, TypeDoc throws away the referenced `ts.Symbol`s, and only stores some rudimentary metadata in the form of a `ReflectionSymbolId`. This “ID” must be resolved back into a regular `ts.Symbol` so that it can be converted properly.

I've tried many ways to do this resolution, most of which led me to dead ends, breaking in one edge-case or another. In the end, I decided to go with an approach that locates the TS AST token that the link points to, and walk back up from there until I arrive at something that can be converted to a symbol. it's not an implementation I'm particularly happy with, but it seems to work, and is mostly resilient to changes in the TS-provided target declaration position.

The current implementation still has some rough edges—namely the error handling will certainly need to change—but I'd like to get some comments on the general approach first, before spending more time on polishing things up.

Closes #33